### PR TITLE
renamed basename conflicting with sdl headers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,43 @@
+examples
+======
+
+qhy5liiviewer
+----------------
+Build and install libqhyccd.so first.
+
+Install libsdl2-image-dev and libcfitsio3-dev
+
+Build qhy5liiviewer using
+
+    g++ -fpermissive -o qhy5liiviewer *c -I../src -lSDL -lSDL_image -lpthread -lusb -lcfitsio -lqhyccd `pkg-config --libs opencv` -DQHY5L_DEBUG
+
+Usage :
+
+<pre><code>
+fphg@mint:examples$ ./qhy5liiviewer --help
+USAGE: qhy5lviewer [options]
+
+OPTIONS:
+  -g | --gain <gain>
+        Sensor Gain<0 - 1000> (default: 100)
+
+  -t | --exposure <exposure>
+        Exposure time in msec (default: 100)
+
+  -f | --file <filename>
+        Output file name to write images (default: image)
+
+  -m | --format <fmt>
+        File type to write (default: FITS, else ppm file will be created.)
+
+  -h | --help
+        Show this message
+
+IN-PROGRAM SHORTCUTS:
+  S -> start/stop frame grabbing
+  P -> gain +10
+  O -> gain -10
+  L -> exposure time +100
+  K -> exposure time -100
+  Q -> exit program
+</code></pre>


### PR DESCRIPTION
- fixed nonexisting OpenCamera()
- added README.md build instructions
- fixed default exposure time to 1000ms
- stripped trailing spaces

this patch allows qhy5liiviewer.c build on my debian amd64.
