### PR TITLE
Example code to show fix issue #5

### DIFF
--- a/demo/QHY5LII-M/initandcapture.cpp
+++ b/demo/QHY5LII-M/initandcapture.cpp
@@ -76,7 +76,8 @@ int main(void)
             goto failure;
         }
 
-        ret = SetQHYCCDResolution(camhandle,1280,960);
+//        ret = SetQHYCCDResolution(camhandle,1280,960);
+        ret = SetQHYCCDResolution(camhandle,640,480);
         if(ret == QHYCCD_SUCCESS)
         {
             printf("Set QHY5LII-M resolution success!\n");
@@ -87,6 +88,17 @@ int main(void)
             goto failure;
         }
         
+        ret = SetQHYCCDParam(camhandle, CONTROL_USBTRAFFIC, 1000);
+        if(ret == QHYCCD_SUCCESS) 
+        {
+            printf("setting USB traffic success!\n");
+        }
+        else
+        {
+            printf("setting USB traffic failure\n");
+            goto failure;
+        }
+
         ret = BeginQHYCCDLive(camhandle);
         if(ret == QHYCCD_SUCCESS)
         {


### PR DESCRIPTION
This is to show example how to fix the issue #5, BeginQHYCCDLive() does not work for QHY5IIL-M, by reducing the resolution to 640x480 and increasing USB traffic to 1000 (default 200).   Please see my experimental results in issue #5.
