### PR TITLE
Initialized image pointer of QHYBase to NULL and invoked parent constructor in all inherited classes

### DIFF
--- a/src/qhy10.cpp
+++ b/src/qhy10.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY10::QHY10()
+QHY10::QHY10() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[2816*3940*3];

--- a/src/qhy11.cpp
+++ b/src/qhy11.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY11::QHY11()
+QHY11::QHY11() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[4096 * 2720 * 3];

--- a/src/qhy12.cpp
+++ b/src/qhy12.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY12::QHY12()
+QHY12::QHY12() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3328*4640*3];

--- a/src/qhy21.cpp
+++ b/src/qhy21.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY21::QHY21()
+QHY21::QHY21() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[2048*1500*3];

--- a/src/qhy22.cpp
+++ b/src/qhy22.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY22::QHY22()
+QHY22::QHY22() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3072*2240*3];

--- a/src/qhy23.cpp
+++ b/src/qhy23.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY23::QHY23()
+QHY23::QHY23() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3468 * 2728 * 3];

--- a/src/qhy5ii.cpp
+++ b/src/qhy5ii.cpp
@@ -41,7 +41,7 @@ int GainTable[] =
 };
 
 
-QHY5II::QHY5II()
+QHY5II::QHY5II() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[1280 * 1024 * 2];

--- a/src/qhy5lii_c.cpp
+++ b/src/qhy5lii_c.cpp
@@ -30,7 +30,7 @@
 #include <opencv/highgui.h>
 
 
-QHY5LII_C::QHY5LII_C()
+QHY5LII_C::QHY5LII_C() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[1280*960*4];

--- a/src/qhy5lii_m.cpp
+++ b/src/qhy5lii_m.cpp
@@ -30,7 +30,7 @@
 #include <opencv/highgui.h>
 
 
-QHY5LII_M::QHY5LII_M()
+QHY5LII_M::QHY5LII_M() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[1280*960*2];

--- a/src/qhy6.cpp
+++ b/src/qhy6.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY6::QHY6()
+QHY6::QHY6() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[800 * 596 * 3];

--- a/src/qhy8.cpp
+++ b/src/qhy8.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY8::QHY8()
+QHY8::QHY8() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3328 * 2030 * 3];

--- a/src/qhy8l.cpp
+++ b/src/qhy8l.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY8L::QHY8L()
+QHY8L::QHY8L() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3328*2030*3];

--- a/src/qhy8pro.cpp
+++ b/src/qhy8pro.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY8PRO::QHY8PRO()
+QHY8PRO::QHY8PRO() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3328 * 2030 * 3];

--- a/src/qhy9s.cpp
+++ b/src/qhy9s.cpp
@@ -31,7 +31,7 @@
 #include <opencv/highgui.h>
 
 
-QHY9S::QHY9S()
+QHY9S::QHY9S() : QHYBASE()
 {
     /* init the tmp buffer for usb transfer */
     rawarray = new unsigned char[3584 * 2574 * 3];

--- a/src/qhybase.h
+++ b/src/qhybase.h
@@ -45,7 +45,7 @@ class QHYBASE:public QHYCAM
 public:
     QHYBASE()
     {
-
+    	monoimg = roiimg = colorimg = NULL;
     }
     ~QHYBASE(){};
     


### PR DESCRIPTION
On systems with Boost somewhat > 1.50 installed, pointer seem not be initialized will NULL by default. Thus, the library fails when it tries to set the camera resolution for the first time cause it is tried to release the image data.