### PR TITLE
Allow installation of firmware and udev rules outside of /lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ install(FILES ${FIRMWARE} DESTINATION "/usr/local/firmware")
 
 ELSE()
 
-set(FIRMWARE_INSTALL_DIR "/lib/firmware/qhy")
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+set(FIRMWARE_INSTALL_DIR "${LIB_INSTALL_DIR}/firmware/qhy")
+set(UDEVRULES_INSTALL_DIR "${LIB_INSTALL_DIR}/udev/rules.d" CACHE STRING "Base directory for udev rules")
 
 IF(UNIX AND NOT WIN32)
  IF (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "armv6l")


### PR DESCRIPTION
This pull request allows firmware and udev rules to be installed in a directory outside of /lib.

Arch does not allow packages to write files to /lib (it's a symlink). Instead packages should write to /usr/lib.
[https://wiki.archlinux.org/index.php/DeveloperWiki:usrlib](https://wiki.archlinux.org/index.php/DeveloperWiki:usrlib)